### PR TITLE
Feature/vault 111

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM golang:1.11.3
+FROM golang:1.11.4
 
 WORKDIR /go/src/github.com/morningconsult/docker-credential-vault-login
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,41 +2,28 @@
 
 
 [[projects]]
-  digest = "1:5ad08b0e14866764a6d7475eb11c9cf05cad9a52c442593bdfa544703ff77f61"
+  digest = "1:4d6f036ea3fe636bcb2e89850bcdc62a771354e157cd51b8b22a2de8562bf663"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = "UT"
-  revision = "0ebda48a7f143b1cce9eb37a8c1106ac762a3430"
-  version = "v0.34.0"
+  revision = "fcb9a2d5f791d07be64506ab54434de65989d370"
+  version = "v0.37.4"
 
 [[projects]]
-  digest = "1:1642d82630adff3904f7965aa1aac2d7bfb8ae93a9b3da849ee38d72bb4c49e7"
+  digest = "1:608b2b045f70e1c7002181db5d614fe8edf6a70bd151c2abcb8928af002bc17b"
   name = "github.com/Jeffail/gabs"
   packages = ["."]
   pruneopts = "UT"
-  revision = "7be49c3f43696c7ca8c9a76d6836703d83aea404"
-  version = "v1.1.1"
+  revision = "74ef14cf8f407ee3ca8ec01bb6f52d6104edea80"
+  version = "v1.2.0"
 
 [[projects]]
-  digest = "1:0803645e1f57fb5271a6edc7570b9ea59bac2e5de67957075a43f3d74c8dbd97"
+  digest = "1:af6e785bedb62fc2abb81977c58a7a44e5cf9f7e41b8d3c8dd4d872edea0ce08"
   name = "github.com/NYTimes/gziphandler"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2600fb119af974220d3916a5916d6e31176aac1b"
-  version = "v1.0.1"
-
-[[projects]]
-  branch = "master"
-  digest = "1:e26170d7ec7d444d7b74a5b1dbd6437fd8e552d27efce9327f733311737c4ae9"
-  name = "github.com/SermoDigital/jose"
-  packages = [
-    ".",
-    "crypto",
-    "jws",
-    "jwt",
-  ]
-  pruneopts = "UT"
-  revision = "803625baeddc3526d01d321b5066029f53eafc81"
+  revision = "dd0439581c7657cb652dfe5c71d7d48baf39541d"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:062c350bc87a8d4cc9a0c69b5c69d113f4dd180e0e3d5904ed398ac3c0c638ab"
@@ -75,7 +62,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:33c0ae567e7a31b6e8747dd64dbad518aa710f29bc4da9da5cebc364571b6dd9"
+  digest = "1:1deff78defc7fb9faa762bf6c7a1f714f227abd4c447a5a80e1d431f4cf5a85e"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -87,6 +74,7 @@
     "aws/credentials",
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
     "aws/credentials/stscreds",
     "aws/csm",
     "aws/defaults",
@@ -96,6 +84,7 @@
     "aws/session",
     "aws/signer/v4",
     "awstesting",
+    "internal/ini",
     "internal/sdkio",
     "internal/sdkrand",
     "internal/sdkuri",
@@ -112,7 +101,16 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "6e42625fcba9345ab67b42b6744284e8f7e3e79d"
+  revision = "130ebb7dc1d6b5a940198b47642fc8b20936a65d"
+  version = "v1.16.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "234731a4f01687625231ac651d6b2776e3f3142e"
 
 [[projects]]
   digest = "1:2da22745c25e0c45d13e15ac825a88b763410694302f10b0f0d7d1c19e0dcc3a"
@@ -132,19 +130,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:095c5b12709e45a61ff2820c2bf81c7de7a030629cb728fc7a2abec35b5cbadb"
+  digest = "1:0bd05495dbd0567480e48eac9e6602d87875a8747b13c3c0fcb7c83c7c921776"
   name = "github.com/fullsailor/pkcs7"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8306686428a5fe132eac8cb7c4848af725098bd4"
-
-[[projects]]
-  digest = "1:19ea97688477f0c05ef94e9ddf48c5a2d8837b4ba781a1014c068293dcca2e5b"
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "f55231ca73a76c1d61eb05fe0d64a1ccebf93cba"
-  version = "v1.39.3"
+  revision = "d7302db945fa6ea264fb79d8e13e931ea514a602"
 
 [[projects]]
   digest = "1:ec6f9bf5e274c833c911923c9193867f3f18788c461f76f05f62bb1510e0ae65"
@@ -155,7 +145,7 @@
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:f26d410f706e6bdfb1576cacf9e4bbd3add8b55a298bf90ab20f588854bad6e0"
+  digest = "1:239c4c7fd2159585454003d9be7207167970194216193a8a210b8d29576f19c9"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -165,15 +155,16 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "ddf22928ea3c56eb4292a0adbbf5001b1e8e7d0d"
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  digest = "1:e4f5819333ac698d294fe04dbf640f84719658d5c7ce195b10060cc37292ce79"
   name = "github.com/golang/snappy"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"
+  version = "v0.0.1"
 
 [[projects]]
   digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
@@ -197,28 +188,28 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:f47d6109c2034cb16bd62b220e18afd5aa9d5a1630fe5d937ad96a4fb7cbb277"
+  digest = "1:af105c7c5dc0b4ae41991f122cae860b9600f7d226072c2a83127048c991660c"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
+  revision = "eda1e5db218aad1db63ca4642c8906b26bcf2744"
+  version = "v0.5.1"
 
 [[projects]]
-  branch = "master"
   digest = "1:33e5020ee072c7859240efaaba71d69eed889a19eaeb0f4ee8dc7a1f0c1afee4"
   name = "github.com/hashicorp/go-gcp-common"
   packages = ["gcputil"]
   pruneopts = "UT"
-  revision = "763e39302965f115fba738b409b320563267b8df"
+  revision = "07c4f8e6aadbb9aa65bd6a651f952365a4ef4d92"
+  version = "v0.5.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:0876aeb6edb07e20b6b0ce1d346655cb63dbe0a26ccfb47b68a9b7697709777b"
+  digest = "1:f6ecb0dc7d965d75815729fd300cc0cd17004fb2d6172a7f37192494936942e5"
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "61d530d6c27f994fb6c83b80f99a69c54125ec8a"
+  revision = "6907afbebd2eef854f0be9194eb79b0ba75d7b29"
 
 [[projects]]
   digest = "1:2be5a35f0c5b35162c41bb24971e5dcf6ce825403296ee435429cdcc4e1e847e"
@@ -229,12 +220,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:19885592ea5b7849d2d04ec2002bd774a3b7573a3f882abe0e069d883abdbdf5"
+  digest = "1:10303616b0698d557e5c36ecfb64fe6dec9a8c8b547ef81ca9330174f9ebd77c"
   name = "github.com/hashicorp/go-memdb"
   packages = ["."]
   pruneopts = "UT"
-  revision = "032f93b25becbfd6c3bb074a1049d98b7e105440"
+  revision = "7e308a4081cf7c23d873ab53a8f3b6bca395e6e8"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
@@ -245,65 +236,69 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:880e48599e7f65dd85eed8092d63ebcbc73715491aec1a857adbce6d9d51d1ac"
+  digest = "1:5e1aece859ec4195f3d16dd3b64a0f111e186b9e95d75141465595063e3a5254"
   name = "github.com/hashicorp/go-plugin"
-  packages = ["."]
+  packages = [
+    ".",
+    "internal/plugin",
+  ]
   pruneopts = "UT"
-  revision = "314501b665e0b2cc71bbd829783179fc38840a85"
+  revision = "52e1c4730856c1438ced7597c9b5c585a7bd06a2"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:183f00c472fb9b2446659618eebf4899872fa267b92f926539411abdc8b941df"
+  digest = "1:1ba2690391610cce08f12c42dd7e8b5f9114a697e85d695280c67b8487cfc38e"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+  revision = "357460732517ec3b57c05c51443296bdd6df1874"
+  version = "v0.5.3"
 
 [[projects]]
-  branch = "master"
-  digest = "1:45aad874d3c7d5e8610427c81870fb54970b981692930ec2a319ce4cb89d7a00"
+  digest = "1:a54ada9beb59fdc35b69322979e870ff0b780e03f4dc309c4c8674b94927df75"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
+  revision = "63503fb4e1eca22f9ae0f90b49c5d5538a0e87eb"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:14f2005c31ddf99c4a0f36fc440f8d1ac43224194c7c4a904b3c8f4ba5654d0b"
+  digest = "1:8abc57884881876d02f467bb7d4ed7ce3a58dac3f8f7ba60579ce4ffc6afd7e1"
   name = "github.com/hashicorp/go-sockaddr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
+  revision = "c7188e74f6acae5a989bdc959aa779f8b9f42faf"
+  version = "v1.0.2"
 
 [[projects]]
-  digest = "1:12ed7dcca9531e58c65cdadb8af0052724bef7fa1581380523fb9cb1215faf0d"
+  digest = "1:f14364057165381ea296e49f8870a9ffce2b8a95e34d6ae06c759106aaef428c"
   name = "github.com/hashicorp/go-uuid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "de160f5c59f693fed329e73e291bb751fe4ea4dc"
-  version = "v1.0.0"
+  revision = "4f571afc59f3043a65f8fe6bf46d887b10a01d43"
+  version = "v1.0.1"
 
 [[projects]]
-  digest = "1:77395dd3847dac9c45118c668f5dab85aedf0163dc3b38aea6578c5cf0d502f9"
+  digest = "1:950caca7dfcf796419232ba996c9c3539d09f26af27ba848c4508e604c13efbb"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b5a281d3160aa11950a6182bd9a9dc2cb1e02d50"
-  version = "v1.0.0"
+  revision = "d40cf49b3a77bba84a7afdbd7f1dc295d114efb1"
+  version = "v1.1.0"
 
 [[projects]]
-  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
+  digest = "1:d15ee511aa0f56baacc1eb4c6b922fa1c03b38413b6be18166b996d82a0156ea"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = "UT"
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:01c267930c063d047b1044d6b2bff0ad967faf37ba639a3eec16a013a16d5f3d"
+  digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -317,10 +312,11 @@
     "json/token",
   ]
   pruneopts = "UT"
-  revision = "65a6292f0157eff210d03ed1bf6c59b190b8b906"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:f8dade4a0d8380b2ddaf461333b19bc9c2289ce7751cdccedf1eb5a988394651"
+  digest = "1:9d78a6fa87ea7397e924610c3f4873a45d329a68cdadfe0738a3a3a25302c47f"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
@@ -346,6 +342,7 @@
     "helper/cidrutil",
     "helper/compressutil",
     "helper/consts",
+    "helper/cryptoutil",
     "helper/dbtxn",
     "helper/dhutil",
     "helper/errutil",
@@ -357,6 +354,7 @@
     "helper/license",
     "helper/locksutil",
     "helper/logging",
+    "helper/metricsutil",
     "helper/mlock",
     "helper/namespace",
     "helper/parseutil",
@@ -387,20 +385,21 @@
     "plugins/helper/database/dbutil",
     "shamir",
     "vault",
+    "vault/replication",
     "vault/seal",
     "version",
   ]
   pruneopts = "UT"
-  revision = "08df121c8b9adcc2b8fd55fc8506c3f9714c7e61"
-  version = "v1.0.1"
+  revision = "a3dcd63451cf6da1d04928b601bbe9748d53842e"
+  version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
   digest = "1:a20fa0b43518234f620bd6fddf21d602769726b462d333fa42e3d2c147a514b0"
   name = "github.com/hashicorp/vault-plugin-auth-alicloud"
   packages = ["tools"]
   pruneopts = "UT"
-  revision = "f278a59ca3e8aeafeda7cb9a14e8815359d25fcd"
+  revision = "eed6384a600fb47b46e97f82d928df1d3d231397"
+  version = "v0.5.0"
 
 [[projects]]
   branch = "master"
@@ -411,12 +410,12 @@
   revision = "2f1d1f20f75d5404f53b9edf6b53ed5505508675"
 
 [[projects]]
-  branch = "master"
-  digest = "1:aa162c457e53f3d6ffebc922cb908c1ec014b67c9d8638a9fe6ed63034123c82"
+  digest = "1:77458e7c8f62f7bb18e84a7408acccc162ec0fcfc77c4d567829698b015f6621"
   name = "github.com/jefferai/jsonx"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9cc31c3135eef39b8e72585f37efa92b6ca314d0"
+  revision = "c32bd0db71409fa22d42d76452191f1516e3c067"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
@@ -426,16 +425,16 @@
   revision = "0b12d6b5"
 
 [[projects]]
-  digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"
+  digest = "1:f5a2051c55d05548d2d4fd23d244027b59fbd943217df8aa3b5e170ac2fd6e1b"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
-  version = "v1.1.5"
+  revision = "0ff49de124c6f76f8494e194af75bde0f1a49a29"
+  version = "v1.1.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:02dff176d57c4b61efe3e0d5b4265c7ea1a75a4efa772908ea4a319093af72dd"
+  digest = "1:8647f03da310f91e13e56ebef1663ea7b757d55e220a8ca53666f7d8c7efaf41"
   name = "github.com/keybase/go-crypto"
   packages = [
     "brainpool",
@@ -453,7 +452,7 @@
     "rsa",
   ]
   pruneopts = "UT"
-  revision = "255a5089e85a475b944ad3c159af0de73fbe66b1"
+  revision = "d65b6b94177fc86b352de754be0aa306de59a759"
 
 [[projects]]
   digest = "1:8ef506fc2bb9ced9b151dafa592d4046063d744c646c1bbe801982ce87e4bc24"
@@ -467,6 +466,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:09ca328575f38b80969ccf857f6d7302f2ce09d53778ea7aaba526cfd2cec739"
   name = "github.com/mitchellh/copystructure"
   packages = ["."]
@@ -475,12 +482,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
+  digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:42eb1f52b84a06820cedc9baec2e710bfbda3ee6dac6cdb97f8b9a5066134ec6"
@@ -531,31 +538,70 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:192ae5ee10b592d53a75b5513986dc4d322652d06bdb7eebcb768b842a309213"
+  digest = "1:808cdddf087fb64baeae67b8dfaee2069034d9704923a3cb8bd96a995421a625"
   name = "github.com/patrickmn/go-cache"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5633e0862627c011927fa39556acae8b1f1df58a"
+  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
+  version = "v2.1.0"
 
 [[projects]]
-  digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"
+  digest = "1:d886a3c32c8c1a770d07e36340f061d3afc948d065ffc3c9a19b01b34d4f0b65"
   name = "github.com/pierrec/lz4"
   packages = [
     ".",
     "internal/xxh32",
   ]
   pruneopts = "UT"
-  revision = "635575b42742856941dbc767b44905bb9ba083f6"
-  version = "v2.0.7"
+  revision = "315a67e90e415bcdaff33057da191569bf4d8479"
+  version = "v2.1.1"
+
+[[projects]]
+  digest = "1:75d51eeab0df85a3cea9e1297ccd3183b20a10cb4b48c753d8ec8d113cc14250"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+  ]
+  pruneopts = "UT"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:5b92d232e81c3e8eec282c92dcaa2e0e1ad3c23157be19a01b3e33f7e6e8d137"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
+
+[[projects]]
+  digest = "1:35cf6bdf68db765988baa9c4f10cc5d7dda1126a54bd62e252dbcd0b1fc8da90"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "a82f4c12f983cc2649298185f296632953e50d3e"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5e412e2a03bd0cfdb102db97212be2e625df74fa8b2d4a8a51f107b1456e256b"
+  name = "github.com/prometheus/procfs"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e22ddced71425e65e388b17b7d0289c5ea77d06e"
+
+[[projects]]
+  digest = "1:6baa565fe16f8657cf93469b2b8a6c61a277827734400d27e44d589547297279"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
   pruneopts = "UT"
-  revision = "256dc444b735e061061cf46c809487313d5b0065"
+  revision = "51a8f68e6c24dc43f1e371749c89a267de4ebc53"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
@@ -566,9 +612,36 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:4cf8287566f3ec70dd67d4d52d34e22af1e70801c24355cb0fbaec9621ab2cf8"
+  digest = "1:ce72568389d111aa2d94b2d6b3c0213ab4699a05cbc6e203ed578f379bedef8f"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+    "trace/tracestate",
+  ]
+  pruneopts = "UT"
+  revision = "75c0cca22312e51bfd4fafdbe9197ae399e18b38"
+  version = "v0.20.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:794673c339145ce036b23cb7b7324c16ec843dfab049fc192df61b641e5b9d87"
   name = "golang.org/x/crypto"
   packages = [
+    "blake2b",
     "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
@@ -579,10 +652,11 @@
     "ssh",
   ]
   pruneopts = "UT"
-  revision = "0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb"
+  revision = "88737f569e3a9c7ab309cdc09a07fe7fc87233c3"
 
 [[projects]]
-  digest = "1:5ad570851feb57bcc5c147ee81a54cdd023a8c66a5c716d57faed25a7b6c1dff"
+  branch = "master"
+  digest = "1:e87f576319e558a57920a69ccdeb7d597f18d5541633c529224c35aa2185e5f4"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -595,11 +669,11 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
+  revision = "eb5bcb51f2a31c7d5141d810b70815c05d9c9146"
 
 [[projects]]
   branch = "master"
-  digest = "1:23443edff0740e348959763085df98400dcfd85528d7771bb0ce9f5f2754ff4a"
+  digest = "1:645cb780e4f3177111b40588f0a7f5950efcfb473e7ff41d8d81b2ba5eaa6ed5"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -609,14 +683,18 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "d668ce993890a79bda886613ee587a69dd5da7a6"
+  revision = "9f3314589c9a9136388751d9adae6b0ed400978a"
 
 [[projects]]
-  digest = "1:0a40b0bdd57a93e741d8557465be3a2edeec408e9b6399586ad65bbe8e355796"
+  branch = "master"
+  digest = "1:e8668d5ed5c474915dfbeef0e32aebafb280803e4efe76950c1b71f60ef39088"
   name = "golang.org/x/sys"
-  packages = ["unix"]
+  packages = [
+    "cpu",
+    "unix",
+  ]
   pruneopts = "UT"
-  revision = "fa43e7bc11baaae89f3f902b2b4d832b68234844"
+  revision = "97732733099d6a942a73b889770774366de963ed"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -642,29 +720,35 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
+  branch = "master"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7d2e564178cc1538b053dbc7a68371648c796693a92b6de20cdc7b04c9ab6534"
+  digest = "1:0568bea2864ad1e0bf363119b5dc5ac4bae18bf0a4841703add2f7abcd87a554"
   name = "google.golang.org/api"
   packages = [
     "compute/v1",
     "gensupport",
     "googleapi",
     "googleapi/internal/uritemplates",
+    "googleapi/transport",
     "iam/v1",
+    "internal",
     "oauth2/v2",
+    "option",
+    "transport/http",
+    "transport/http/internal/propagation",
   ]
   pruneopts = "UT"
-  revision = "583d854617af4d2080b5d2a24d72f7fc5a128ab2"
+  revision = "0cbcb99a9ea0c8023c794b2693cbe1def82ed4d7"
+  version = "v0.3.2"
 
 [[projects]]
-  digest = "1:7bc25c2efff76b31f146caf630c617be9b666c6164f0632050466fbec0500125"
+  digest = "1:b08971e2f39ffd6a0b627e7ef1918f178bfcf1ca00d70fc35fb8f4812682afb6"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -680,19 +764,19 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
-  version = "v1.4.0"
+  revision = "54a98f90d1c46b7731eb8fb305d2a321c30ef610"
+  version = "v1.5.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:077c1c599507b3b3e9156d17d36e1e61928ee9b53a5b420f10f28ebd4a0b275c"
+  digest = "1:c3076e7defee87de1236f1814beb588f40a75544c60121e6eb38b3b3721783e2"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "5a97ab628bfb2f65f6befec18f4bc7bc7f382b77"
+  revision = "64821d5d210748c883cd2b809589555ae4654203"
 
 [[projects]]
-  digest = "1:03af1505694005143ff6dc5d0e2802c8200ddb618b1d3f7201482f53798b99b4"
+  digest = "1:33cd55021749f5411a96e2d6b96079b5ce5f9bbaca9ffad110c5fab318623490"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -711,6 +795,7 @@
     "health/grpc_health_v1",
     "internal",
     "internal/backoff",
+    "internal/balancerload",
     "internal/binarylog",
     "internal/channelz",
     "internal/envconfig",
@@ -730,20 +815,21 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "df014850f6dee74ba2fc94874043a9f3f75fbfd8"
-  version = "v1.17.0"
+  revision = "236199dd5f8031d698fb64091194aecd1c3895b2"
+  version = "v1.20.0"
 
 [[projects]]
-  digest = "1:feab1308bceeb3d0e078b1c10397f2ce3b9d6f030c209d46e8b6f62fc97f90f3"
+  digest = "1:9593bab40e981b1f90b7e07faeab0d09b75fe338880d08880f986a9d3283c53f"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
     "cipher",
     "json",
+    "jwt",
   ]
   pruneopts = "UT"
-  revision = "72415094398e2f013bf50b76fd6de36df47938ea"
-  version = "v2.2.1"
+  revision = "730df5f748271903322feb182be83b43ebbbe27d"
+  version = "v2.3.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/hashicorp/vault"
-  version = "1.0.1"
+  version = "1.1.1"
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,16 @@
 FLY := $(shell which fly)
 
 BIN_DIR := $(shell pwd)/bin
-REPO=github.com/morningconsult/docker-credential-vault-login
+REPO := github.com/morningconsult/docker-credential-vault-login
 SOURCES := $(shell find . -name '*.go')
-BINARY_NAME=docker-credential-vault-login
-LOCAL_BINARY=bin/local/$(BINARY_NAME)
-EXTERNAL_TOOLS=\
+BINARY_NAME := docker-credential-vault-login
+LOCAL_BINARY := bin/local/$(BINARY_NAME)
+
+EXTERNAL_TOOLS := \
 	github.com/golang/mock/mockgen \
 	golang.org/x/tools/cmd/goimports
 
+.DEFAULT_GOAL := all
 
 all: build
 
@@ -74,16 +76,20 @@ CONCOURSE_PIPELINE := docker-credential-vault-login
 
 
 check_fly:
-	if [ -z "$(FLY)" ]; then \
-		sudo mkdir -p /usr/local/bin; \
-		sudo wget -q -O /usr/local/bin/fly "https://ci.morningconsultintelligence.com/api/v1/cli?arch=amd64&platform=linux"; \
-		sudo chmod +x /usr/local/bin/fly; \
-		/usr/local/bin/fly --version; \
-	fi
+ifeq ($(FLY),)
+		sudo mkdir -p /usr/local/bin
+		sudo wget -q -O /usr/local/bin/fly "https://ci.morningconsultintelligence.com/api/v1/cli?arch=amd64&platform=linux"
+		sudo chmod +x /usr/local/bin/fly
+		/usr/local/bin/fly --version
+endif
 .PHONY: check_fly
 
 
 set_pipeline: check_fly
+	$(FLY) --target mci-ci-oss validate-pipeline \
+		--config ci/pipeline.yml \
+		--strict
+
 	$(FLY) --target mci-ci-oss set-pipeline \
 		--config ci/pipeline.yml \
 		--pipeline $(CONCOURSE_PIPELINE) \

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -25,7 +25,7 @@ resources:
 - name: test-pull-request
   type: pull-request
   source:
-    repository: morningconsult/go-elasticsearch-alerts
+    repository: morningconsult/docker-credential-vault-login
     access_token: ((github-token))
 
 - name: new-release
@@ -87,6 +87,7 @@ jobs:
     params:
       path: test-pull-request
       status: pending
+      context: test-pr
   - task: test-pr
     image: golang
     file: test-pull-request/ci/tasks/test-pull-request.yml
@@ -95,14 +96,14 @@ jobs:
       params:
         path: test-pull-request
         status: success
-        context: $BUILD_JOB_NAME
+        context: test-pr
     on_failure:
       do:
       - put: test-pull-request
         params:
           path: test-pull-request
           status: failure
-          context: $BUILD_JOB_NAME
+          context: test-pr
       - put: slack
         params: {alert_type: failed}
     on_abort:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,13 +6,12 @@
 # ====================================
 resource_types:
 - name: slack-alert
-  type: docker-image
+  type: registry-image
   source:
     repository: arbourd/concourse-slack-alert-resource
-    channel: '#build'
 
 - name: pull-request
-  type: docker-image
+  type: registry-image
   source:
     repository: jtarchie/pr
 
@@ -42,7 +41,7 @@ resources:
     tag_filter: 'v[0-9]*'
 
 - name: golang
-  type: docker-image
+  type: registry-image
   source:
     repository: golang
     tag: 1.11.3-alpine3.8
@@ -95,7 +94,6 @@ jobs:
         path: test-pull-request
         status: success
         context: $BUILD_JOB_NAME
-        comment: test-pull-request/ci/pr_test_success
     on_failure:
       do:
       - put: test-pull-request
@@ -103,7 +101,6 @@ jobs:
           path: test-pull-request
           status: failure
           context: $BUILD_JOB_NAME
-          comment: test-pull-request/ci/pr_test_failure
       - put: slack
         params: {alert_type: failed}
     on_abort:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,7 +13,7 @@ resource_types:
 - name: pull-request
   type: registry-image
   source:
-    repository: jtarchie/pr
+    repository: teliaoss/github-pr-resource
 
 
 # ====================================
@@ -25,11 +25,8 @@ resources:
 - name: test-pull-request
   type: pull-request
   source:
-    private_key: ((github-private-key))
+    repository: morningconsult/go-elasticsearch-alerts
     access_token: ((github-token))
-    repo: morningconsult/docker-credential-vault-login
-    uri: ((github-repo))
-    base: master
 
 - name: new-release
   type: git
@@ -44,7 +41,7 @@ resources:
   type: registry-image
   source:
     repository: golang
-    tag: 1.11.3-alpine3.8
+    tag: 1.11.4-alpine3.8
 
 - name: slack
   type: slack-alert
@@ -82,9 +79,14 @@ jobs:
   build_logs_to_retain: 30
   serial: true
   plan:
-  - get: test-pull-request
-    trigger: true
-  - get: golang
+  - aggregate:
+    - get: test-pull-request
+      trigger: true
+    - get: golang
+  - put: test-pull-request
+    params:
+      path: test-pull-request
+      status: pending
   - task: test-pr
     image: golang
     file: test-pull-request/ci/tasks/test-pull-request.yml

--- a/ci/pr_test_failure
+++ b/ci/pr_test_failure
@@ -1,2 +1,0 @@
-### Concourse CI
-Tests failing :x:

--- a/ci/pr_test_success
+++ b/ci/pr_test_success
@@ -1,2 +1,0 @@
-### Concourse CI
-All tests passing :white_check_mark:

--- a/helper/client.go
+++ b/helper/client.go
@@ -30,7 +30,7 @@ func newVaultClient(method *config.Method) (*api.Client, error) {
 		api.EnvVaultClientCert,
 		api.EnvVaultClientKey,
 		api.EnvVaultClientTimeout,
-		api.EnvVaultInsecure,
+		api.EnvVaultSkipVerify,
 		api.EnvVaultTLSServerName,
 		api.EnvVaultMaxRetries,
 	}

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -817,7 +817,7 @@ func TestHelper_parseConfig(t *testing.T) {
 		{
 			"empty-file",
 			"testdata/empty-file.hcl",
-			"error parsing 'auto_auth': one and only one \"auto_auth\" block is required",
+			"no 'auto_auth' block found",
 		},
 		{
 			"no-method",


### PR DESCRIPTION
Changes:

- Update Vault client to 1.1.1. This includes a number of performance improvements to how the vault agent works, especially with caching
- Updates the version of Go used to test/build to 1.11.4
- Update a number of things in the CI pipeline for changes to concourse 5.0.0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.