### PR TITLE
Handle unlisted registries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,8 @@ func (s SecretsTable) GetPath(registry string) (string, error) {
 		return s.oneSecret, nil
 	}
 
+	registry = strings.ToLower(registry)
+
 	// Add scheme if one is not present so url.Parse works as expected
 	if !strings.HasPrefix(registry, "http://") && !strings.HasPrefix(registry, "https://") {
 		registry = "http://" + registry
@@ -73,7 +75,12 @@ func (s SecretsTable) GetPath(registry string) (string, error) {
 		registry = registry + ":" + u.Port()
 	}
 
-	return s.registryToSecret[registry], nil
+	secret, ok := s.registryToSecret[registry]
+	if !ok {
+		return "", errors.New("registry \"" + registry + "\" not found in configuration")
+	}
+
+	return secret, nil
 }
 
 // LoadConfig will parse the configuration file and return a
@@ -198,7 +205,7 @@ func secretsTableFromMap(secretsRaw interface{}) (SecretsTable, error) {
 
 	for host, pathRaw := range secretsArr[0] {
 		if path, ok := pathRaw.(string); ok && path != "" && host != "" {
-			obj[host] = path
+			obj[strings.ToLower(host)] = path
 		}
 	}
 


### PR DESCRIPTION
*Description of changes:*
If the user chooses to use different registries for different secrets, but then attempts to pull from a registry not listed in the configuration file, then the helper returns an error. For example, if a user has this configuration file:
```hcl
auto_auth {
	method "approle" {
		mount_path = "auth/approle"
		config = {
			role_id_file_path   = "/tmp/role-id"
			secret_id_file_path = "/tmp/secret-id"
			secrets = {
				registry-1.example.com = "secret/docker/creds"
				registry-2.example.com = "secret/docker/extra/creds"
				"localhost:5000"       = "secret/docker/localhost/creds"
			}
		}
	}
}
```
and he then attempts to execute `docker pull registry-3.example.com` (not included in the `auto_auth.method.config.secrets` block) the helper will return an error, log the error, and terminate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.