### PR TITLE
Address edge case for non renewing tokens

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -136,12 +136,15 @@ func (h *Helper) Get(serverURL string) (string, string, error) { // nolint: gocy
 			h.logger.Info("no cached token(s) were read. Re-authenticating.")
 		}
 
-		// Renew the cached tokens
 		var validTokens []string
+
+		// Renew the cached tokens
 		for _, token := range cachedTokens {
 			if _, err = h.client.Auth().Token().RenewTokenAsSelf(token, 0); err != nil {
 				h.logger.Info("Issue renewing token. Will Re-authenticate", "error", err)
+				continue
 			}
+
 			validTokens = append(validTokens, token)
 		}
 


### PR DESCRIPTION

*Description of changes:*
This clarifies some errors that aren't actually errors for the use case where tokens are not renewable. The new behavior excludes tokens that weren't renewed and limits grabbing credentials for tokens that will not succeed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.