### PR TITLE
chore: increase default timeout to 30s

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	errNotImplemented  = errors.New("not implemented")
-	defaultAuthTimeout = 10 * time.Second
+	defaultAuthTimeout = 30 * time.Second
 )
 
 type secretTable interface {


### PR DESCRIPTION
10s can sometimes not be enough time when using
the AWS auth method, as AWS is slow and annoying. These
timeouts can lead to failed image pulls.

Signed-off-by: Alex Dulin <alex@morningconsult.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.