### PR TITLE
fix: typo in token_file auto_auth method type

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -190,7 +190,7 @@ func BuildAuthMethod(config *config.Method, logger hclog.Logger) (auth.AuthMetho
 		method, err = kubernetes.NewKubernetesAuthMethod(authConfig)
 	case "approle":
 		method, err = approle.NewApproleAuthMethod(authConfig)
-	case "token-file":
+	case "token_file":
 		method, err = token_file.NewTokenFileAuthMethod(authConfig)
 	default:
 		return nil, xerrors.Errorf("unknown auth method %q", config.Type)


### PR DESCRIPTION
The docs mention `token_file` to be written with an underscore instead of a dash: https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth/methods/token_file

Writing it with a dash will result in an error on runtime:

```
error parsing configuration file: error parsing 'auto_auth': error parsing 'method': unknown auto-auth method type token-file
```

Without this fix, opening it with an underscore, will result in this error:

```
error creating auth method: unknown auth method "token_file"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.